### PR TITLE
Fixes strong params on reports

### DIFF
--- a/app/controllers/api/v2/omaha_reports_controller.rb
+++ b/app/controllers/api/v2/omaha_reports_controller.rb
@@ -40,7 +40,7 @@ module Api
       param_group :omaha_report, :as => :create
 
       def create
-        @omaha_report = resource_class.import(params[:omaha_report], detected_proxy.try(:id))
+        @omaha_report = resource_class.import(params.to_unsafe_h[:omaha_report], detected_proxy.try(:id))
         process_response @omaha_report.errors.empty?
       rescue ::Foreman::Exception => e
         render_message(e.to_s, :status => :unprocessable_entity)


### PR DESCRIPTION
I'm not sure if this is a problem or not but it was for openscap and core reports after core was update to newer version of rails. We need to mark params as "safe" since they are coming from proxy so we don't expect any insidious params from properly authenticated internal system.