### PR TITLE
breadcrumb bar: resource_class must not be private

### DIFF
--- a/app/controllers/omaha_groups_controller.rb
+++ b/app/controllers/omaha_groups_controller.rb
@@ -16,8 +16,6 @@ class OmahaGroupsController < ApplicationController
     @oem_distribution = ForemanOmaha::Charts::OemDistribution.new(@omaha_group.hosts)
   end
 
-  private
-
   def model_of_controller
     ::ForemanOmaha::OmahaGroup
   end


### PR DESCRIPTION
Restore compatibility with https://github.com/theforeman/foreman/pull/5525#pullrequestreview-120953650