### PR TITLE
Use os version fact facet instead of os release

### DIFF
--- a/app/views/omaha_hosts/index.html.erb
+++ b/app/views/omaha_hosts/index.html.erb
@@ -20,7 +20,7 @@
               <% if host.operatingsystem %>
                 <div class="list-view-pf-additional-info-item">
                   <%= icon(host.operatingsystem, :size => '16x16') %>&nbsp;
-                  <%= link_to_if_authorized(host.operatingsystem.release, hash_for_edit_operatingsystem_path(host.operatingsystem)) %>
+                  <%= link_to_if_authorized(host.omaha_facet.version, hash_for_edit_operatingsystem_path(host.operatingsystem)) %>
                 </div>
               <% end %>
               <div class="list-view-pf-additional-info-item" style="white-space: nowrap;">


### PR DESCRIPTION
* os release reflects the os at time of installation, if you are running
foreman with "Stop updating Operating System from facts" and coreos is
auto updating this will not reflect the currently running os.  Updating
the report to use host.omaha_facet.version will reflect the currently
running os.