### PR TITLE
Fixes #28992 - Add description to plugin roles

### DIFF
--- a/lib/foreman_omaha/engine.rb
+++ b/lib/foreman_omaha/engine.rb
@@ -50,7 +50,7 @@ module ForemanOmaha
 
         role 'Omaha reports viewer',
              [:view_omaha_reports],
-             'This role can view Omaha reports.'
+             'Role granting permissions to view Omaha reports.'
         role 'Omaha reports manager',
              [:view_omaha_reports, :destroy_omaha_reports, :upload_omaha_reports],
              'Role granting permissions to manage Omaha reports.'

--- a/lib/foreman_omaha/engine.rb
+++ b/lib/foreman_omaha/engine.rb
@@ -50,10 +50,10 @@ module ForemanOmaha
 
         role 'Omaha reports viewer',
              [:view_omaha_reports],
-             'TODO: Description'
+             'This role can view Omaha reports.'
         role 'Omaha reports manager',
              [:view_omaha_reports, :destroy_omaha_reports, :upload_omaha_reports],
-             'TODO: Description'
+             'This role can manage Omaha reports.'
 
         # add menu entry
         menu :top_menu, :omaha_reports,

--- a/lib/foreman_omaha/engine.rb
+++ b/lib/foreman_omaha/engine.rb
@@ -53,7 +53,7 @@ module ForemanOmaha
              'This role can view Omaha reports.'
         role 'Omaha reports manager',
              [:view_omaha_reports, :destroy_omaha_reports, :upload_omaha_reports],
-             'This role can manage Omaha reports.'
+             'Role granting permissions to manage Omaha reports.'
 
         # add menu entry
         menu :top_menu, :omaha_reports,

--- a/lib/foreman_omaha/engine.rb
+++ b/lib/foreman_omaha/engine.rb
@@ -49,9 +49,11 @@ module ForemanOmaha
         end
 
         role 'Omaha reports viewer',
-             [:view_omaha_reports]
+             [:view_omaha_reports],
+             'TODO: Description'
         role 'Omaha reports manager',
-             [:view_omaha_reports, :destroy_omaha_reports, :upload_omaha_reports]
+             [:view_omaha_reports, :destroy_omaha_reports, :upload_omaha_reports],
+             'TODO: Description'
 
         # add menu entry
         menu :top_menu, :omaha_reports,


### PR DESCRIPTION
PR is part of  [Add default descriptions to all roles added from plugins](https://projects.theforeman.org/issues/28936) task.