### PR TITLE
do not load non-existant charts.js

### DIFF
--- a/app/views/omaha_groups/show.html.erb
+++ b/app/views/omaha_groups/show.html.erb
@@ -1,5 +1,4 @@
 <% javascript 'foreman_omaha/application' %>
-<% javascript 'charts' %>
 <% title @omaha_group.name %>
 <%= breadcrumbs(
     items: [


### PR DESCRIPTION
We used charts.js from Foreman, but that was dropped in Foreman 3.0 (https://github.com/theforeman/foreman/commit/69379b51a33344de93836950565ecbfae0c4df23) and results in 404 errors when trying to load some pages

Fixes: 28d49d8c43b2f3ae6ea112590074386ab7dd4d18