### PR TITLE
Fix Style/RedundantParentheses cop

### DIFF
--- a/app/models/foreman_omaha/omaha_facet.rb
+++ b/app/models/foreman_omaha/omaha_facet.rb
@@ -11,7 +11,7 @@ module ForemanOmaha
 
     belongs_to :omaha_group, :inverse_of => :omaha_facets, :class_name => 'ForemanOmaha::OmahaGroup'
 
-    scope :out_of_sync, ->(*args) { where(['last_report < ?', (args.first || (30 + Setting[:outofsync_interval]).minutes.ago)]) }
+    scope :out_of_sync, ->(*args) { where(['last_report < ?', args.first || (30 + Setting[:outofsync_interval]).minutes.ago]) }
 
     validates_lengths_from_database
 


### PR DESCRIPTION
Addressed the `Style/RedundantParentheses` cop by removing unnecessary parentheses in the `out_of_sync` scope, check commit for the changes.