### PR TITLE
Fix Ruby 3.3 constant lookup for HostStatus

### DIFF
--- a/lib/foreman_omaha/engine.rb
+++ b/lib/foreman_omaha/engine.rb
@@ -28,7 +28,7 @@ module ForemanOmaha
 
         apipie_documented_controllers ["#{ForemanOmaha::Engine.root}/app/controllers/api/v2/*.rb"]
 
-        register_custom_status HostStatus::OmahaStatus
+        register_custom_status ::HostStatus::OmahaStatus
 
         # Add permissions
         security_block :foreman_omaha do


### PR DESCRIPTION
## Summary

- Qualify `HostStatus` with `::` prefix in engine.rb plugin registration block

On Ruby 3.3 (shipped with EL10), constant lookup inside `instance_eval` blocks no longer falls through to top-level scope. The unqualified `HostStatus::OmahaStatus` reference on line 31 causes:

```
NameError: uninitialized constant ForemanOmaha::Engine::HostStatus
```

This breaks the `plugin:assets:precompile` rake task during RPM build, preventing the package from building on EL10.

Other Foreman plugins (e.g. `foreman_openscap`) already use fully qualified constants like `ForemanOpenscap::ComplianceStatus` in the same context and work correctly.